### PR TITLE
SYM-7813: Exclude flow-build-info.json from vaadin-chartjs jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ hs_err_pid*
 *.iml
 package*json
 webpack*js
+/frontend/generated/
+/frontend/index.html

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
+                    <!-- Add-on jars must never carry the application build token.
+                         prepare-frontend generates it into target/classes; excluding it
+                         here keeps it out of the jar regardless of the build profile. -->
+                    <excludes>
+                        <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,6 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
-                    <!-- Add-on jars must never carry the application build token.
-                         prepare-frontend generates it into target/classes; excluding it
-                         here keeps it out of the jar regardless of the build profile. -->
                     <excludes>
                         <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
                     </excludes>


### PR DESCRIPTION
The published add-on jar was including META-INF/VAADIN/config/flow-build-info.json, Vaadin's build token that records productionMode as false and absolute paths to the CI machine where it was built. When a consuming application (symmetric-pro) put this jar on its classpath, Vaadin read the add-on's stray dev-mode token, assumed the whole app was in development mode, and failed at startup trying to access a frontend folder that only existed on the build runner (IllegalStateException: Running project in development mode with no access to folder ...). This happened regardless of the consumer building in production mode, since the flag controls the app's own token, not one leaked inside a dependency. This PR excludes flow-build-info.json from the add-on jar in the default maven-jar-plugin config, so add-ons ship only classes and frontend resources and never override the consumer's production token. It also gitignores the frontend/generated/ and frontend/index.html build artifacts.