### PR TITLE
SYM-7813: bump version to 0.1.47 for production-mode fix release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.jumpmind.symmetric</groupId>
     <artifactId>vaadin-chartjs</artifactId>
-    <version>0.1.46</version>
+    <version>0.1.47</version>
 	<name>ChartJs add-on for Vaadin 25+</name>
     <description>Integration of ChartJs for Vaadin platform</description>
     <url>https://github.com/jumpmindinc/symmetric-vaadin-chartjs</url>


### PR DESCRIPTION
Bumps the add-on version to 0.1.47 so the production-mode fix (excluding `flow-build-info.json` from the add-on jar, merged previously) can be published to Maven Central. 0.1.46 is already released and immutable on Central, so a new version is required for consumers to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)